### PR TITLE
Switch bracket expansion to semantic selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config option `working_directory`
 - Config group `debug` with the options `debug.log_level`, `debug.print_events`
     and `debug.ref_test`
-- Bracket-pair selection logic, double-clicking `{` in `hello { world }` selects `{ world }`,
-  works for `{}[]()<>`, (see [#2022](https://github.com/jwilm/alacritty/pull/2022))
+- Select until next matching bracket when double-clicking a bracket
 
 ### Changed
 

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -114,21 +114,6 @@ impl<'a, N: Notify + 'a> input::ActionContext for ActionContext<'a, N> {
         self.terminal.dirty = true;
     }
 
-    // bracket_pair_selection updates the selection from the starting bracket
-    // up to and including the equal bracket pair.
-    //
-    // If the char at `point` is not a valid bracket, the selection will not be
-    // mutated, to allow other selection algorithms to update the selection.
-    fn bracket_pair_selection(&mut self, point: Point) {
-        let point = self.terminal.visible_to_buffer(point);
-        let start_char = self.terminal.grid()[point.line][point.col].c;
-        let selection = Selection::bracket_pair(point, start_char, self.terminal);
-        if selection.is_some() {
-            *self.terminal.selection_mut() = selection;
-            self.terminal.dirty = true;
-        }
-    }
-
     fn mouse_coords(&self) -> Option<Point> {
         self.terminal.pixels_to_coords(self.mouse.x as usize, self.mouse.y as usize)
     }
@@ -235,7 +220,6 @@ impl WindowChanges {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ClickState {
     None,
     Click,

--- a/alacritty_terminal/src/index.rs
+++ b/alacritty_terminal/src/index.rs
@@ -28,15 +28,6 @@ pub enum Side {
     Right,
 }
 
-impl Side {
-   pub fn opposite(self) -> Self {
-       match self {
-           Side::Left => Side::Right,
-           Side::Right => Side::Left,
-       }
-   }
-}
-
 /// Index in the grid using row, column notation
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, PartialOrd)]
 pub struct Point<L = Line> {

--- a/alacritty_terminal/src/selection.rs
+++ b/alacritty_terminal/src/selection.rs
@@ -25,9 +25,6 @@ use crate::index::{Column, Point, Side};
 use crate::term::cell::Flags;
 use crate::term::{Search, Term};
 
-/// Used to match equal brackets, when performing a bracket-pair selection.
-const BRACKET_PAIRS: [(char, char); 4] = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
-
 /// Describes a region of a 2-dimensional area
 ///
 /// Used to track a text selection. There are three supported modes, each with its own constructor:
@@ -60,10 +57,6 @@ pub enum Selection {
         /// The line under the initial point. This is always selected regardless
         /// of which way the cursor is moved.
         initial_line: isize,
-    },
-    BracketPair {
-        /// The region representing start and end of bracket pairs.
-        region: Range<Anchor>,
     },
 }
 
@@ -111,9 +104,6 @@ impl Selection {
                 region.end.line += offset;
                 *initial_line += offset;
             },
-            // BracketPair selections are (conditionally) triggered once, and
-            // don't need to be updated.
-            Selection::BracketPair { .. } => {},
         }
     }
 
@@ -128,29 +118,6 @@ impl Selection {
         }
     }
 
-    pub fn bracket_pair<T>(point: Point<usize>, start_char: char, search: &T) -> Option<Selection>
-    where
-        T: Search,
-    {
-        BRACKET_PAIRS.iter().find_map(|(open, close)| {
-            let (side, end_char) = match &start_char {
-                c if c == open => (Side::Right, *close),
-                c if c == close => (Side::Left, *open),
-                _ => return None,
-            };
-
-            let search_back = side == Side::Left;
-            search.bracket_pair_search(point, search_back, start_char, end_char).map(|end_point| {
-                Selection::BracketPair {
-                    region: Range {
-                        start: Anchor::new(point.into(), side.opposite()),
-                        end: Anchor::new(end_point.into(), side),
-                    },
-                }
-            })
-        })
-    }
-
     pub fn update(&mut self, location: Point<usize>, side: Side) {
         // Always update the `end`; can normalize later during span generation.
         match *self {
@@ -160,17 +127,12 @@ impl Selection {
             Selection::Semantic { ref mut region } | Selection::Lines { ref mut region, .. } => {
                 region.end = location.into();
             },
-            // BracketPair selections are (conditionally) triggered once, and
-            // don't need to be updated.
-            Selection::BracketPair { .. } => {},
         }
     }
 
     pub fn to_span(&self, term: &Term, alt_screen: bool) -> Option<Span> {
         let span = match *self {
-            Selection::Simple { ref region } | Selection::BracketPair { ref region } => {
-                Selection::span_simple(term, region, alt_screen)
-            },
+            Selection::Simple { ref region } => Selection::span_simple(term, region, alt_screen),
             Selection::Semantic { ref region } => {
                 Selection::span_semantic(term, region, alt_screen)
             },
@@ -201,7 +163,7 @@ impl Selection {
 
     pub fn is_empty(&self) -> bool {
         match *self {
-            Selection::Simple { ref region } | Selection::BracketPair { ref region } => {
+            Selection::Simple { ref region } => {
                 region.start == region.end && region.start.side == region.end.side
             },
             Selection::Semantic { .. } | Selection::Lines { .. } => false,
@@ -226,14 +188,20 @@ impl Selection {
             Selection::alt_screen_clamp(&mut start, &mut end, lines, cols)?;
         }
 
-        let (mut start, mut end) = if start < end && start.line == end.line {
+        let (mut start, mut end) = if start == end {
+            if let Some(end) = grid.bracket_search(start.into()) {
+                (start.into(), end)
+            } else {
+                (grid.semantic_search_right(start.into()), grid.semantic_search_left(end.into()))
+            }
+        } else if start < end && start.line == end.line {
             (grid.semantic_search_left(start.into()), grid.semantic_search_right(end.into()))
         } else {
             (grid.semantic_search_right(start.into()), grid.semantic_search_left(end.into()))
         };
 
         if start > end {
-            ::std::mem::swap(&mut start, &mut end);
+            std::mem::swap(&mut start, &mut end);
         }
 
         Some(Span { start, end })

--- a/alacritty_terminal/src/term/mod.rs
+++ b/alacritty_terminal/src/term/mod.rs
@@ -46,6 +46,9 @@ use crate::tty;
 pub mod cell;
 pub mod color;
 
+/// Used to match equal brackets, when performing a bracket-pair selection.
+const BRACKET_PAIRS: [(char, char); 4] = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
+
 /// A type that can expand a given point to a region
 ///
 /// Usually this is implemented for some 2-D array type since
@@ -57,14 +60,8 @@ pub trait Search {
     fn semantic_search_right(&self, _: Point<usize>) -> Point<usize>;
     /// Find the nearest URL boundary in both directions.
     fn url_search(&self, _: Point<usize>) -> Option<Url>;
-    /// Find the first bracket matching the pair.
-    fn bracket_pair_search(
-        &self,
-        start: Point<usize>,
-        search_back: bool,
-        start_char: char,
-        end_char: char,
-    ) -> Option<Point<usize>>;
+    /// Find the nearest matching bracket.
+    fn bracket_search(&self, _: Point<usize>) -> Option<Point<usize>>;
 }
 
 impl Search for Term {
@@ -146,40 +143,47 @@ impl Search for Term {
         url_parser.url()
     }
 
-    fn bracket_pair_search(
-        &self,
-        start: Point<usize>,
-        search_back: bool,
-        start_char: char,
-        end_char: char,
-    ) -> Option<Point<usize>> {
-        let mut iter = self.grid.iter_from(start);
+    fn bracket_search(&self, point: Point<usize>) -> Option<Point<usize>> {
+        let start_char = self.grid[point.line][point.col].c;
+
+        // Find the matching bracket we're looking for
+        let (forwards, end_char) = BRACKET_PAIRS.iter().find_map(|(open, close)| {
+            if open == &start_char {
+                Some((true, *close))
+            } else if close == &start_char {
+                Some((false, *open))
+            } else {
+                None
+            }
+        })?;
+
+        let mut iter = self.grid.iter_from(point);
+
         // For every character match that equals the starting bracket, we
         // ignore one bracket of the opposite type.
         let mut skip_pairs = 0;
 
-        let mut match_bracket = |c: char| -> bool {
-            skip_pairs += match c {
-                c if c == end_char && skip_pairs == 0 => return true,
-                c if c == start_char => 1,
-                c if c == end_char => -1,
-                _ => 0,
+        loop {
+            // Check the next cell
+            let cell = if forwards { iter.next() } else { iter.prev() };
+
+            // Break if there are no more cells
+            let c = match cell {
+                Some(cell) => cell.c,
+                None => break,
             };
 
-            false
-        };
-
-        if search_back {
-            while let Some(cell) = iter.prev() {
-                if match_bracket(cell.c) {
-                    return Some(iter.cur);
-                }
+            // Check if the bracket matches
+            if c == end_char && skip_pairs == 0 {
+                return Some(iter.cur);
+            } else if c == start_char {
+                skip_pairs += 1;
+            } else if c == end_char {
+                skip_pairs -= 1;
             }
-
-            return None;
         }
 
-        iter.find(|cell| match_bracket(cell.c)).map(|_| iter.cur)
+        None
     }
 }
 


### PR DESCRIPTION
I'm sorry for the long delay, but I've finally found some time to review your PR.

I've noticed that your current version had an issue where it would first jump to a semantic selection and then expand into the bracket selection and I was wondering how that could be resolved. After playing around with your PR for a little bit, I've had the idea to build on top of the semantic selection for this.

I think my changes should be a bit more consistent and reduce the flickering when starting semantic/bracket selections. Though it is possible I might have missed some edge-cases so please let me know what you think.

I've mostly used what you've already written, but a lot of that wasn't necessary with this implementation anymore, so it might be simpler to compare it against master to see the full diff of how this approach works. In general I think it's a bit less complex than your implementation, but I think that might serve us quite well.

Instead of using a separate selection mechanism, this uses the semantic
selection to expand it to brackets if its width spans no cells.